### PR TITLE
Replace timebar with status bar

### DIFF
--- a/annotator.py
+++ b/annotator.py
@@ -381,7 +381,7 @@ class Annotator:
         img = np.concatenate((bar, img), axis=0)
         return img
 
-    def add_statusbar(self, img):
+    def add_statusbar(self, img, frame):
         '''Add a status bar which displays the selected label, current page, and current frame'''
         img = np.concatenate((img, np.zeros((self.timebar_h, img.shape[1], 3))), axis=0)
         # text parameters
@@ -395,6 +395,18 @@ class Annotator:
         cv2.putText(img, label_text, (0, height + (label_offset[1] // 2)), cv2.FONT_HERSHEY_SIMPLEX, font_size, (1,1,1))
         (name_offset, _) = cv2.getTextSize(label['name'], cv2.FONT_HERSHEY_SIMPLEX, font_size, 1)
         cv2.putText(img, label['name'], (label_offset[0], height + (name_offset[1] // 2)), cv2.FONT_HERSHEY_SIMPLEX, font_size, label['color'])
+
+        # draw the current page
+        page_text = 'Page: %i/%i' % (self.current_page + 1, self.N_pages)
+        (page_offset, _) = cv2.getTextSize(page_text, cv2.FONT_HERSHEY_SIMPLEX, font_size, 1)
+        page_x = int((self.mosaic.shape[2] / 2) - (page_offset[0] / 2))
+        cv2.putText(img, page_text, (page_x, height + (page_offset[1] // 2)), cv2.FONT_HERSHEY_SIMPLEX, font_size, (1,1,1))
+
+        # draw current frame
+        time_text = 'Frame: %i/%i' % (frame + 1, self.mosaic.shape[0])
+        (time_offset, _) = cv2.getTextSize(time_text, cv2.FONT_HERSHEY_SIMPLEX, font_size, 1)
+        frame_x = self.mosaic.shape[2] - time_offset[0]
+        cv2.putText(img, time_text, (frame_x, height + (time_offset[1] // 2)), cv2.FONT_HERSHEY_SIMPLEX, font_size, (1,1,1))
         return img
 
     def load_annotations(self):
@@ -669,7 +681,7 @@ class Annotator:
                     # Draw annotation box, timebar, and statusbar
                     self.draw_anno_box(img)
                     img = self.add_timebar(img, f/self.mosaic.shape[0])
-                    img = self.add_statusbar(img)
+                    img = self.add_statusbar(img, f)
 
                     # Detect if window was closed
                     if cv2.getWindowProperty('MuViLab', 0) < 0:

--- a/annotator.py
+++ b/annotator.py
@@ -378,9 +378,22 @@ class Annotator:
         bar[:, 0:idt, 0] = color[0]
         bar[:, 0:idt, 1] = color[1]
         bar[:, 0:idt, 2] = color[2]
-        img = np.concatenate((bar, img, bar), axis=0)
+        img = np.concatenate((bar, img), axis=0)
         return img
 
+    def add_statusbar(self, img):
+        '''Add a status bar which displays the selected label, current page, and current frame'''
+        img = np.concatenate((img, np.zeros((self.timebar_h, img.shape[1], 3))), axis=0)
+        # text parameters
+        font_size = 0.4
+        height = self.mosaic.shape[1] + int(1.6 * self.timebar_h)
+        label = self.labels[self.selected_label]
+
+        # draw 'Selected label: <label>' at the bottom left
+        label_text = 'Selected label: '
+        (label_offset, _) = cv2.getTextSize(label_text, cv2.FONT_HERSHEY_SIMPLEX, font_size, 1)
+        cv2.putText(img, label_text, (0, height), cv2.FONT_HERSHEY_SIMPLEX, font_size, (1,1,1))
+        cv2.putText(img, label['name'], (label_offset[0], height), cv2.FONT_HERSHEY_SIMPLEX, font_size, label['color'])
 
     def load_annotations(self):
         '''Load annotations from self.annotation_file'''
@@ -654,7 +667,8 @@ class Annotator:
                     # Draw annotation box and timebar
                     self.draw_anno_box(img)
                     img = self.add_timebar(img, f/self.mosaic.shape[0])
-                    
+                    img = self.add_statusbar(img)
+
                     # Detect if window was closed
                     if cv2.getWindowProperty('MuViLab', 0) < 0:
                         run = None

--- a/annotator.py
+++ b/annotator.py
@@ -386,14 +386,16 @@ class Annotator:
         img = np.concatenate((img, np.zeros((self.timebar_h, img.shape[1], 3))), axis=0)
         # text parameters
         font_size = 0.4
-        height = self.mosaic.shape[1] + int(1.6 * self.timebar_h)
+        height = self.mosaic.shape[1] + int(1.5 * self.timebar_h)
         label = self.labels[self.selected_label]
 
         # draw 'Selected label: <label>' at the bottom left
         label_text = 'Selected label: '
         (label_offset, _) = cv2.getTextSize(label_text, cv2.FONT_HERSHEY_SIMPLEX, font_size, 1)
-        cv2.putText(img, label_text, (0, height), cv2.FONT_HERSHEY_SIMPLEX, font_size, (1,1,1))
-        cv2.putText(img, label['name'], (label_offset[0], height), cv2.FONT_HERSHEY_SIMPLEX, font_size, label['color'])
+        cv2.putText(img, label_text, (0, height + (label_offset[1] // 2)), cv2.FONT_HERSHEY_SIMPLEX, font_size, (1,1,1))
+        (name_offset, _) = cv2.getTextSize(label['name'], cv2.FONT_HERSHEY_SIMPLEX, font_size, 1)
+        cv2.putText(img, label['name'], (label_offset[0], height + (name_offset[1] // 2)), cv2.FONT_HERSHEY_SIMPLEX, font_size, label['color'])
+        return img
 
     def load_annotations(self):
         '''Load annotations from self.annotation_file'''
@@ -664,7 +666,7 @@ class Annotator:
                 for f in range(self.mosaic.shape[0]):
                     tic = time.time()
                     img = np.copy(self.mosaic[f, ...])
-                    # Draw annotation box and timebar
+                    # Draw annotation box, timebar, and statusbar
                     self.draw_anno_box(img)
                     img = self.add_timebar(img, f/self.mosaic.shape[0])
                     img = self.add_statusbar(img)


### PR DESCRIPTION
The current label, page and frame is displayed at the bottom instead of a second timebar.